### PR TITLE
chore: 🤖  Dont throw error if locale not found, return undefined instead

### DIFF
--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -33,7 +33,7 @@ describe("findLocale", () => {
     expect(consoleWarnSpy).toBeCalledTimes(1);
   });
 
-  it("Should throw LocaleNotSupported error if not found", () => {
-    expect(() => findLocale(supportedLocales, "foo")).toThrow();
+  it("Should return undefined if not found", () => {
+    expect(findLocale(supportedLocales, "foo")).toBeUndefined();
   });
 });

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,4 +1,7 @@
-export function findLocale(supportedLocales: string[], locale: string): string {
+export function findLocale(
+  supportedLocales: string[],
+  locale: string,
+): string | undefined {
   if (supportedLocales.includes(locale)) {
     return locale;
   }
@@ -10,24 +13,19 @@ export function findLocale(supportedLocales: string[], locale: string): string {
       return localeToMatch;
     }
   }
-  throw new LocaleNotSupportedError(`Locale ${locale} was not found`);
+  return undefined;
 }
-
-export class LocaleNotSupportedError extends Error {}
 
 export function getBrowserLocale(
   supportedLocales: string[],
   fallbackLocale?: string,
 ) {
+  let browserLocale: string | undefined;
   if (typeof window !== "undefined" && window.navigator.language) {
-    try {
-      return findLocale(supportedLocales, window.navigator.language);
-    } catch (_) {}
-    if (!fallbackLocale) {
-      try {
-        return findLocale(supportedLocales, "en");
-      } catch (_) {}
+    browserLocale = findLocale(supportedLocales, window.navigator.language);
+    if (!browserLocale && !fallbackLocale) {
+      browserLocale = findLocale(supportedLocales, "en");
     }
   }
-  return fallbackLocale || supportedLocales[0] || "en";
+  return browserLocale || fallbackLocale || supportedLocales[0] || "en";
 }


### PR DESCRIPTION
I use `Utils.findLocale()` in trucknet-io to avoid code duplication but it throws error when locale not found which is something unusual for the "find" function. Wrapping it with try catch each time seems very redundant when I just want to fallback to the predefined locale, for example :
```ts
const localePath = Utils.findLocale(APP_SUPPORTED_LOCALES, locale) || "en";
return (
    <Link to={`${APP}/${to}/${localePath}`} external {...rest} />
);
```
In any case "find" is something that **may not** return value if it's not found. So I think that throwing exception for the **may not** case is wrong. If it was **must return** case then I would understand.