### PR TITLE
Fixes warning not to be shown in tests

### DIFF
--- a/.env-cmdrc
+++ b/.env-cmdrc
@@ -2,9 +2,6 @@
   "development": {
     "NODE_ENV": "development"
   },
-  "staging": {
-    "NODE_ENV": "production"
-  },
   "production": {
     "NODE_ENV": "production"
   }

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ react-targem makes it possible to change locale and have all the application's t
 <!--size-start-->
 
 ```
-      5.56 kB: index.min.mjs
-      2.36 kB: index.min.mjs.gz
-      2.13 kB: index.min.mjs.br
+      5.59 kB: index.min.mjs
+      2.39 kB: index.min.mjs.gz
+      2.16 kB: index.min.mjs.br
 
-      7.11 kB: index.umd.min.js
-      2.78 kB: index.umd.min.js.gz
-      2.51 kB: index.umd.min.js.br
+      7.13 kB: index.umd.min.js
+      2.81 kB: index.umd.min.js.gz
+      2.54 kB: index.umd.min.js.br
 ```
 
 <!--size-end-->

--- a/bundle-sizes.lock
+++ b/bundle-sizes.lock
@@ -1,7 +1,7 @@
-      5.56 kB: index.min.mjs
-      2.36 kB: index.min.mjs.gz
-      2.13 kB: index.min.mjs.br
+      5.59 kB: index.min.mjs
+      2.39 kB: index.min.mjs.gz
+      2.16 kB: index.min.mjs.br
 
-      7.11 kB: index.umd.min.js
-      2.78 kB: index.umd.min.js.gz
-      2.51 kB: index.umd.min.js.br
+      7.13 kB: index.umd.min.js
+      2.81 kB: index.umd.min.js.gz
+      2.54 kB: index.umd.min.js.br

--- a/package-lock.json
+++ b/package-lock.json
@@ -4593,7 +4593,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4614,12 +4615,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4634,17 +4637,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4761,7 +4767,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4773,6 +4780,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4787,6 +4795,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4794,12 +4803,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4818,6 +4829,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4898,7 +4910,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4910,6 +4923,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4995,7 +5009,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5031,6 +5046,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5050,6 +5066,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5093,12 +5110,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -12385,13 +12404,13 @@
       "dependencies": {
         "qs": {
           "version": "6.5.2",
-          "resolved": false,
+          "resolved": "http://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
           "dev": true
         },
         "webpack-combine-loaders": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "http://registry.npmjs.org/webpack-combine-loaders/-/webpack-combine-loaders-2.0.4.tgz",
           "integrity": "sha1-J4FNUrgyntZWW+OQCarHY2Hn4iw=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:tslint": "tslint -c tslint.json -p ./dev/tsconfig.json --fix",
     "start": "env-cmd -e development webpack-dev-server --config dev/webpack.config.js --hot",
     "prebuild": "npm run clean",
-    "build": "npm run build:tsc && rollup -c config/rollup.config.js && rollup -c config/rollup.config.js --environment NODE_ENV:production",
+    "build": "env-cmd -e production npm run build:tsc && rollup -c config/rollup.config.js && rollup -c config/rollup.config.js",
     "build:tsc": "tsc -p ./config/tsconfig.build.json && tsc -p ./config/tsconfig.build.json --target es2018 --outDir dist/esm2015",
     "postbuild": "npm run rename-mjs && npm run size",
     "rename-mjs": "node ./config/renameMjs.js",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:tslint": "tslint -c tslint.json -p ./dev/tsconfig.json --fix",
     "start": "env-cmd -e development webpack-dev-server --config dev/webpack.config.js --hot",
     "prebuild": "npm run clean",
-    "build": "env-cmd -e production npm run build:tsc && rollup -c config/rollup.config.js && rollup -c config/rollup.config.js",
+    "build": "npm run build:tsc && rollup -c config/rollup.config.js && env-cmd -e production rollup -c config/rollup.config.js",
     "build:tsc": "tsc -p ./config/tsconfig.build.json && tsc -p ./config/tsconfig.build.json --target es2018 --outDir dist/esm2015",
     "postbuild": "npm run rename-mjs && npm run size",
     "rename-mjs": "node ./config/renameMjs.js",

--- a/src/utils/debug.spec.ts
+++ b/src/utils/debug.spec.ts
@@ -15,7 +15,7 @@ describe("warn()", () => {
 
     warn("Alert!");
     expect(spy).toBeCalledWith(`react-targem: Alert!
-***This message is shown only when NODE_ENV !== "production"***`);
+***This message is shown only when NODE_ENV is "development" and DISABLE_TARGEM_WARNINGS is not set***`);
     spy.mockClear();
   });
 

--- a/src/utils/debug.spec.ts
+++ b/src/utils/debug.spec.ts
@@ -8,7 +8,9 @@ jest.mock("./constants", () => ({
 
 describe("warn()", () => {
   test("outputs warning to the console in debug mode", () => {
-    const spy = jest.spyOn(global.console, "warn");
+    const spy = jest
+      .spyOn(global.console, "warn")
+      .mockImplementationOnce(() => undefined);
     const { warn } = jest.requireActual("./debug") as {
       warn(msg: string): void;
     };
@@ -21,7 +23,9 @@ describe("warn()", () => {
 
   test("does nothing in production mode", () => {
     DEBUG = false;
-    const spy = jest.spyOn(global.console, "warn");
+    const spy = jest
+      .spyOn(global.console, "warn")
+      .mockImplementationOnce(() => undefined);
     const { warn } = jest.requireActual("./debug") as {
       warn(msg: string): void;
     };

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -3,7 +3,7 @@ import { DEBUG } from "./constants";
 export function warn(message: string) {
   if (DEBUG) {
     console.warn(
-      `react-targem: ${message}\n***This message is shown only when NODE_ENV !== "production"***`,
+      `react-targem: ${message}\n***This message is shown only when NODE_ENV is "development" and DISABLE_TARGEM_WARNINGS is not set***`,
     );
   }
 }

--- a/src/utils/locale.spec.ts
+++ b/src/utils/locale.spec.ts
@@ -1,18 +1,11 @@
+import { warn } from "./debug";
 import { findLocale } from "./locale";
 
 const supportedLocales = ["en-GB", "en-AU"];
 
-let consoleWarnSpy: jest.SpyInstance;
-
 describe("findLocale", () => {
-  beforeAll(() => {
-    consoleWarnSpy = jest
-      .spyOn(global.console, "warn")
-      .mockImplementation(() => undefined);
-  });
-
   afterEach(() => {
-    consoleWarnSpy.mockClear();
+    (warn as jest.Mock).mockClear();
   });
 
   it("should return en-GB for en-GB", () => {
@@ -25,12 +18,12 @@ describe("findLocale", () => {
 
   it("should return en-GB for en and do a warning", () => {
     expect(findLocale(supportedLocales, "en")).toBe("en-GB");
-    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(warn).toBeCalledTimes(1);
   });
 
   it("should return en-GB for en-US and do a warning", () => {
     expect(findLocale(supportedLocales, "en-US")).toBe("en-GB");
-    expect(consoleWarnSpy).toBeCalledTimes(1);
+    expect(warn).toBeCalledTimes(1);
   });
 
   it("Should return undefined if not found", () => {

--- a/src/utils/locale.ts
+++ b/src/utils/locale.ts
@@ -1,3 +1,5 @@
+import { warn } from "./debug";
+
 export function findLocale(
   supportedLocales: string[],
   locale: string,
@@ -7,7 +9,7 @@ export function findLocale(
   }
   for (const localeToMatch of supportedLocales) {
     if (localeToMatch.includes(locale.split("-")[0])) {
-      console.warn(
+      warn(
         `Locale ${locale} was not found. Using ${localeToMatch} as a fallback`,
       );
       return localeToMatch;


### PR DESCRIPTION
Found a weird bug.

If you look at the compiled version of the code (`node_modules/react-targem/dist/bundles/index.umd.js:102`, you will notice this:

```
    var DEBUG = false;
    if (typeof process !== "undefined") {
        DEBUG = !!(process &&
            process.env &&
            "development" === "development" &&
            !process.env.DISABLE_TARGEM_WARNINGS);
    }
```

And of course  `"development" === "development"` will always be true