### PR TITLE
chore: 🤖  Added TargemStatefulBase to exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ react-targem makes it possible to change locale and have all the application's t
 <!--size-start-->
 
 ```
-         6 kB: index.min.mjs
-      2.52 kB: index.min.mjs.gz
+      6.03 kB: index.min.mjs
+      2.53 kB: index.min.mjs.gz
       2.27 kB: index.min.mjs.br
 
-      7.53 kB: index.umd.min.js
+      7.55 kB: index.umd.min.js
       2.94 kB: index.umd.min.js.gz
       2.65 kB: index.umd.min.js.br
 ```

--- a/bundle-sizes.lock
+++ b/bundle-sizes.lock
@@ -1,7 +1,7 @@
-         6 kB: index.min.mjs
-      2.52 kB: index.min.mjs.gz
+      6.03 kB: index.min.mjs
+      2.53 kB: index.min.mjs.gz
       2.27 kB: index.min.mjs.br
 
-      7.53 kB: index.umd.min.js
+      7.55 kB: index.umd.min.js
       2.94 kB: index.umd.min.js.gz
       2.65 kB: index.umd.min.js.br

--- a/src/components/TargemStatefulProvider.tsx
+++ b/src/components/TargemStatefulProvider.tsx
@@ -11,7 +11,7 @@ import {
 
 export type WithLocaleStateful = Required<WithLocale>;
 
-class TargemStatefulBase extends TargemProvider<{
+export class TargemStatefulBase extends TargemProvider<{
   changeLocale(locale: string): void;
 }> {
   protected getValue = memoizeOne(


### PR DESCRIPTION
This export is useful to make custom `TranslationsProvider` for trucknet-io that fetches translations asynchronously but still extends `TargemStatefulProvider` from react-targem to avoid writing the same logic for `changeLocale` context.